### PR TITLE
fix select_groups()

### DIFF
--- a/msd/db.py
+++ b/msd/db.py
@@ -84,8 +84,8 @@ def select_groups(db, table_name, key_cols, cols=None):
     from_cols_sql = col_sql(cols) if cols else '*'
     key_sql = col_sql(key_cols)
 
-    select_sql = 'SELECT {} FROM `{}` GROUP BY {} ORDER BY {}'.format(
-        from_cols_sql, table_name, key_sql, key_sql)
+    select_sql = 'SELECT {} FROM `{}` ORDER BY {}'.format(
+        from_cols_sql, table_name, key_sql)
 
     for key, rows in groupby(
             db.execute(select_sql),

--- a/msd/db.py
+++ b/msd/db.py
@@ -93,6 +93,7 @@ def select_groups(db, table_name, key_cols, cols=None):
 
         yield key, [dict(row) for row in rows]
 
+
 def show_tables(db):
     """List the tables in the given db."""
     sql = "SELECT name FROM sqlite_master WHERE type = 'table'"

--- a/test/db.py
+++ b/test/db.py
@@ -36,9 +36,11 @@ def select_all(db, table_name):
 def sorted_rows(rows):
     """Sort rows by the value of each key, in alphabetical order
     (for easy testing of equality)."""
+    # avoid comparing values of different types; Python 3 dislikes this
     return sorted(
         rows,
-        key=lambda row: sorted((k, repr(v)) for (k, v) in row.items()))
+        key=lambda row: sorted((k, (type(v).__name__, v))
+                               for (k, v) in row.items()))
 
 
 def strip_null(row):

--- a/test/db.py
+++ b/test/db.py
@@ -28,10 +28,17 @@ from msd.table import TABLES
 
 def select_all(db, table_name):
     """Get all rows from a table, and sort (for easy testing of equality)."""
+    return sorted_rows(
+        dict(row) for row in
+        db.execute('SELECT * FROM `{}`'.format(table_name)))
+
+
+def sorted_rows(rows):
+    """Sort rows by the value of each key, in alphabetical order
+    (for easy testing of equality)."""
     return sorted(
-        (dict(row) for row in
-         db.execute('SELECT * FROM `{}`'.format(table_name))),
-        key=lambda row: [(k, repr(v)) for (k, v) in row.items()])
+        rows,
+        key=lambda row: sorted((k, repr(v)) for (k, v) in row.items()))
 
 
 def strip_null(row):

--- a/test/unit/msd/test_db.py
+++ b/test/unit/msd/test_db.py
@@ -1,0 +1,62 @@
+# Copyright 2015 SpendRight, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from msd.db import insert_row
+from msd.db import select_groups
+
+from ...db import DBTestCase
+from ...db import insert_rows
+from ...db import sorted_rows
+
+
+class TestSelectGroups(DBTestCase):
+
+    OUTPUT_TABLES = ['scraper_company_map']
+
+    def test_empty(self):
+        self.assertEqual(
+            list(select_groups(
+                self.output_db, 'scraper_company_map', ['company'])),
+            [])
+
+    def test_one_row_group(self):
+        ONE_ROW = dict(
+            company='Foo',
+            scraper_company='Foo',
+            scraper_id='sr.campaign.bar')
+
+        insert_row(self.output_db, 'scraper_company_map', ONE_ROW)
+
+        self.assertEqual(
+            list(select_groups(
+                self.output_db, 'scraper_company_map', ['company'])),
+            [(('Foo',), [ONE_ROW])])
+
+    def test_two_row_group(self):
+        TWO_ROWS = [
+            dict(company='Foo',
+                 scraper_company='Foo',
+                 scraper_id='sr.campaign.bar'),
+            dict(company='Foo',
+                 scraper_company='Foo & Co.',
+                 scraper_id='sr.campaign.qux'),
+        ]
+
+        insert_rows(self.output_db, 'scraper_company_map', TWO_ROWS)
+
+        groups = [(key, sorted_rows(rows))
+                  for key, rows in select_groups(
+                          self.output_db, 'scraper_company_map', ['company'])]
+
+        self.assertEqual(groups,
+                         [(('Foo',), TWO_ROWS)])


### PR DESCRIPTION
Ouch, `select_groups()` was only returning one row per group, which discarded a lot of data.
