### PR TITLE
Read in YAML, fix missing brand field

### DIFF
--- a/msd/cmd.py
+++ b/msd/cmd.py
@@ -57,7 +57,7 @@ def parse_args(args=None):
     parser = ArgumentParser()
     parser.add_argument(
         dest='input_dbs', nargs='+',
-        help='SQLite databases to merge')
+        help='SQLite databases and/or YAML database dumps to merge')
     parser.add_argument(
         '-v', '--verbose', dest='verbose', default=False, action='store_true',
         help='Enable debug logging')

--- a/msd/scratch.py
+++ b/msd/scratch.py
@@ -217,7 +217,8 @@ def clean_input_row(row, table_name):
     """Clean each value in the given row of input data, and remove
     extra columns."""
     table_def = TABLES.get(table_name, {})
-    valid_cols = set(table_def.get('columns', ())) | {'scraper_id'}
+    column_types = table_def.get('columns', {})
+    valid_cols = set(column_types) | {'scraper_id'}
 
     cleaned = {}
 
@@ -229,5 +230,12 @@ def clean_input_row(row, table_name):
             value = clean_string(value)
 
         cleaned[col_name] = value
+
+    # make sure primary key columns aren't null or unset
+    for key_col_name in table_def.get('primary_key', ()):
+        if cleaned.get(key_col_name) is None:
+            if column_types.get(key_col_name) == 'text':
+                cleaned[key_col_name] = ''
+            # currently all our primary key columns are text
 
     return cleaned

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+PyYAML>=3.11
 Unidecode>=0.04.9
 titlecase>=0.7.1

--- a/test/unit/msd/test_scratch.py
+++ b/test/unit/msd/test_scratch.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 from unittest import TestCase
 
+from msd.scratch import clean_input_row
 from msd.scratch import parse_input_path
 
 
@@ -36,3 +37,19 @@ class TestParseInputPath(TestCase):
     def test_uppercase_format(self):
         self.assertEqual(parse_input_path('DATA.YAML'),
                          ('DATA', 'yaml'))
+
+
+# partial test, for newly added feature
+class TestCleanInputRow(TestCase):
+
+    def test_empty(self):
+        self.assertEqual(clean_input_row({}, 'foo'), {})
+
+    def test_add_primary_key_columns(self):
+        self.assertEqual(
+            clean_input_row({}, 'claim'),
+            dict(campaign_id='',
+                 company='',
+                 brand='',
+                 scope='',
+                 claim=''))

--- a/test/unit/msd/test_scratch.py
+++ b/test/unit/msd/test_scratch.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SpendRight, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import TestCase
+
+from msd.scratch import parse_input_path
+
+
+class TestParseInputPath(TestCase):
+
+    def test_empty(self):
+        self.assertRaises(ValueError, parse_input_path, '')
+
+    def test_sqlite(self):
+        self.assertEqual(parse_input_path('sr.company.sqlite'),
+                         ('sr.company', 'sqlite'))
+
+    def test_yaml(self):
+        self.assertEqual(parse_input_path('manual/detox_catwalk.yaml'),
+                         ('manual/detox_catwalk', 'yaml'))
+
+    def test_other_format(self):
+        self.assertRaises(ValueError, parse_input_path, 'README.txt')
+
+    def test_uppercase_format(self):
+        self.assertEqual(parse_input_path('DATA.YAML'),
+                         ('DATA', 'yaml'))


### PR DESCRIPTION
This change allows us to read input as either SQLite or YAML (or a combination) (see #36).

Also fixed a bug where if you didn't set the `brand` field in a row (say, in your manually entered YAML data), that row would be skipped when selecting by target (see #37).
