### PR TITLE
company name corrections

### DIFF
--- a/msd/__init__.py
+++ b/msd/__init__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '0.1.5'
+__version__ = '0.1.5.dev0'

--- a/msd/__init__.py
+++ b/msd/__init__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '0.1.5.dev0'
+__version__ = '0.2.0.dev0'

--- a/msd/cmd.py
+++ b/msd/cmd.py
@@ -34,17 +34,15 @@ def main(args=None):
     set_up_logging(verbose=opts.verbose, quiet=opts.quiet)
 
     run(input_db_paths=opts.input_dbs, scratch_db_path=opts.scratch_db,
-        output_db_path=opts.output_db, force_rebuild_scratch=opts.force)
+        output_db_path=opts.output_db)
 
 
 def run(*,
-        force_rebuild_scratch=False,
         input_db_paths=(),
         output_db_path=DEFAULT_OUTPUT_DB,
         scratch_db_path=DEFAULT_SCRATCH_DB):
 
-    build_scratch_db(scratch_db_path, input_db_paths,
-                     force=force_rebuild_scratch)
+    build_scratch_db(scratch_db_path, input_db_paths)
 
     build_output_db(scratch_db_path, output_db_path)
 
@@ -71,7 +69,7 @@ def parse_args(args=None):
         help='Turn off info logging')
     parser.add_argument(
         '-f', '--force', dest='force', default=False, action='store_true',
-        help='Force rebuild of scratch DB, even if newer than input')
+        help='Does nothing (scratch DB is always rebuilt)')
     parser.add_argument(
         '-i', '--scratch', dest='scratch_db',
         default=DEFAULT_SCRATCH_DB,

--- a/msd/cmd.py
+++ b/msd/cmd.py
@@ -14,6 +14,7 @@
 import logging
 from argparse import ArgumentParser
 
+import msd
 from msd.output import build_output_db
 from msd.scratch import build_scratch_db
 
@@ -25,6 +26,10 @@ log = logging.getLogger('msd.cmd')
 
 def main(args=None):
     opts = parse_args()
+
+    if opts.version:
+        print(msd.__version__)
+        return
 
     set_up_logging(verbose=opts.verbose, quiet=opts.quiet)
 
@@ -56,7 +61,7 @@ def set_up_logging(*, verbose=False, quiet=False):
 def parse_args(args=None):
     parser = ArgumentParser()
     parser.add_argument(
-        dest='input_dbs', nargs='+',
+        dest='input_dbs', nargs='*',
         help='SQLite databases and/or YAML database dumps to merge')
     parser.add_argument(
         '-v', '--verbose', dest='verbose', default=False, action='store_true',
@@ -74,6 +79,9 @@ def parse_args(args=None):
     parser.add_argument(
         '-o', '--output', dest='output_db', default=DEFAULT_OUTPUT_DB,
         help='Path to output DB (default: %(default)s)')
+    parser.add_argument(
+        '-V', '--version', dest='version', default=False,
+        action='store_true', help='Print version and exit')
 
     return parser.parse_args(args)
 

--- a/msd/company.py
+++ b/msd/company.py
@@ -35,7 +35,7 @@ from .url import match_urls
 log = getLogger(__name__)
 
 
-# use this to turn e.g. "babyGap" into "baby Gap"
+# use this to turn e.g. "babyGap" into "baby Gap" for matching
 # this can also turn "G.I. Joe" into "G. I. Joe"
 CAMEL_CASE_RE = re.compile('(?<=[a-z\.])(?=[A-Z])')
 
@@ -172,7 +172,11 @@ def build_company_name_and_scraper_company_map_tables(output_db, scratch_db):
                 scraper_company=scraper_company))
 
         # write to company_name
-        for company_name in sorted(names | cd['aliases']):
+
+        # company and company_full should always be in cd; just hedging
+        company_names = cd['names'] | cd['aliases'] | {company, company_full}
+
+        for company_name in company_names:
             row = dict(company=company, company_name=company_name)
 
             if company_name == company_full:
@@ -356,5 +360,7 @@ def load_company_name_corrections(scratch_db):
 
         elif row['is_full']:
             sc_to_full[sc].add(row['company_name'])
+
+        cds.append(cd)
 
     return cds, invariant_names, sc_to_bad, sc_to_full

--- a/msd/company_data.py
+++ b/msd/company_data.py
@@ -11,100 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Supporting data for msd.companies."""
+"""Regexes etc. for parsing company names."""
 import re
-
-# various misspellings of company names
-COMPANY_CORRECTIONS = {
-    'Delta Airlines': 'Delta Air Lines',
-    'GEPA- The Fairtrade Company': 'GEPA - The Fairtrade Company',
-    'Groupo Modelo S.A.B. de C.V.': 'Grupo Modelo S.A.B. de C.V.',
-    'Hanesbrands Incorporated': 'Hanesbrands Inc.',
-    'Nescafe': 'Nestlé',  # Nescafé is a brand, not a company
-    'PUMA AG Rudolf Dassler Sport': 'Puma SE',
-    'SAB Miller': 'SABMiller',
-    'V.F. Corporation': 'VF Corporation',
-    'Wolverine Worldwide': 'Wolverine World Wide',
-    'Woolworths Australia': 'Woolworths Limited',
-    'Chocoladefabriken Lindt & Sprungli': 'Lindt & Sprüngli AG',
-}
-
-# Name changes. May eventually want separate logic for this.
-COMPANY_CORRECTIONS.update({
-    'Clean Clothes, Inc.': "Maggie's Functional Organics",
-    'Limited Brands': 'L Brands',
-    'Limited Brands, Inc.': 'L Brands Inc.',
-    'Liz Claiborne': 'Kate Spade & Company',
-    'Sweet Earth Chocolates': 'Mama Ganache',  # renamed in 2012
-    'RIM': 'BlackBerry Limited', # renamed in 2013
-    'Research In Motion': 'BlackBerry Limited',
-    'Lindt & Sprüngli GmbH': 'Lindt & Sprüngli AG',  # changed corporate form
-})
-
-DEFUNCT_COMPANIES = {
-    'Armor Holdings',  # acquired by BAE Systems in 2007, integrated
-    'Jones Apparel Group',  # acquired by Nine West Inc.
-    'The Jones Group',  # another name for Jones Apparel Group
-    'News Corporation',  # split into News Corp, 21st Century Fox
-}
-
-# sets of names to match companies by
-COMPANY_ALIASES = [
-    {'LG', 'LGE'},
-    {'AEO', 'American Eagle', 'American Eagle Outfitters'},
-    {'Merck', 'Schering-Plough'},  # merged into Merck
-]
-
-# don't shorten company names to these
-BAD_COMPANY_ALIASES = {
-    'News',  # e.g. News Corporation, News Corp.
-}
-
-# don't use these as display names unless we have no other options
-BAD_COMPANY_NAMES = {
-    'American Eagle',
-    'LGE',
-}
-
-# sets of valid names for the same company
-COMPANY_NAMES = [
-    {'AB Electrolux', 'Electrolux'},
-    {'American Eagle Outfitters'},
-    {'Anheuser-Busch', 'Anheuser-Busch InBev'},
-    {'ASUS', 'ASUSTeK Computer'},
-    {'Disney', 'The Walt Disney Company', 'The Walt Disney Co.'},
-    {'Gap', 'The Gap'},  # might solve this with "Gap" brand?
-    {'GE', 'General Electric'},
-    {'HP', 'Hewlett-Packard'},
-    {'HTC Electronics', 'HTC'},
-    {'Illy', 'illycaffè'},
-    {'JetBlue', 'JetBlue Airways'},
-    {'Kellogg', "Kellogg's"},  # might solve this with a brand?
-    {'L Brands', 'Limited Brands'},
-    {'Lindt', 'Lindt & Sprüngli'},
-    {'Lidl', 'Lidl Stiftung'},
-    {'LG', 'LG Electronics'},
-    {'New Look', 'New Look Retailers'},
-    {'Philips', 'Royal Philips', 'Royal Philips Electronics'},
-    {'PVH', 'Phillips Van Heusen'},
-    {'Rivers Australia', 'Rivers (Australia) Pty Ltd'},
-    # technically, Wells Fargo Bank, N.A. is a subsidiary of Wells Fargo
-    # the multinational. Not worrying about this now and I don't think this is
-    # what they meant anyway.
-    {'Wells Fargo', 'Wells Fargo Bank'},
-    {'Whole Foods', 'Whole Foods Market'},
-    {'Wibra', 'Wibra Supermarkt'},
-]
 
 # always keep this suffix on the company name
 UNSTRIPPABLE_COMPANY_TYPES = {
     'LLP',
-}
-
-# don't use the regexes below to shorten these company names
-UNSTRIPPABLE_COMPANIES = {
-    'Globe International',
-    'Woolworths Limited',
 }
 
 # "The X Co." -- okay to strip

--- a/msd/company_data.py
+++ b/msd/company_data.py
@@ -172,7 +172,7 @@ COMPANY_TYPE_RE = re.compile(
     r'|B\.V\.'
     r'|B.V. Nederland'
     r'|C\.V\.'
-    r'|Corp.'
+    r'|Corp\.?'
     r'|GmbH \& C[oO]\. [oO]HG'
     r'|GmbH \& Co\. ?KG\.?'  # handle typo: Lukas Meindl GmbH & Co.KG
     r'|GmbH \& Co\. KGaA'
@@ -221,6 +221,7 @@ COMPANY_TYPE_RE = re.compile(
 
 COMPANY_TYPE_CORRECTIONS = {
     'BV': 'B.V.',
+    'Corp': 'Corp.',
     'Incorporated': 'Inc',
     'Llc': 'LLC',
     'Llp': 'LLP',

--- a/msd/scratch.py
+++ b/msd/scratch.py
@@ -18,6 +18,7 @@ from logging import getLogger
 from os import remove
 from os import rename
 from os.path import exists
+from os.path import normpath
 
 from .db import create_index
 from .db import create_table
@@ -108,7 +109,7 @@ def parse_input_path(path):
 
     file_type will be one of 'sqlite' or 'yaml'
     """
-    m = _INPUT_PATH_RE.match(path)
+    m = _INPUT_PATH_RE.match(normpath(path))
     if not m:
         raise ValueError('Unknown input file type: {}'.format(path))
     return m.group('scraper_prefix'), m.group('extension').lower()

--- a/msd/scratch.py
+++ b/msd/scratch.py
@@ -18,7 +18,6 @@ from logging import getLogger
 from os import remove
 from os import rename
 from os.path import exists
-from os.path import getmtime
 
 from .db import create_index
 from .db import create_table
@@ -35,13 +34,9 @@ _INPUT_PATH_RE = re.compile(
     r'^(?P<scraper_prefix>.*)\.(?P<extension>(sqlite|yaml))$', re.I)
 
 
-def build_scratch_db(
-        scratch_db_path, input_db_paths, *, force=False):
+def build_scratch_db(scratch_db_path, input_db_paths):
     """Take data from the various input databases, and put it into
     a single, indexed database with correct table definitions.
-
-    Does nothing if the scratch DB is newer than all the input
-    DBs, unless *force* is true.
 
     Unlike the output database, every table in the scratch database
     has a scraper_id field. The names of each input database are used
@@ -53,15 +48,6 @@ def build_scratch_db(
     This also cleans smart quotes, excess whitespace, etc. out of the
     input data.
     """
-    # TODO: might also want to apply custom corrections here
-    if exists(scratch_db_path) and not force:
-        mtime = getmtime(scratch_db_path)
-        if all(exists(db_path) and getmtime(db_path) < mtime
-               for db_path in input_db_paths):
-            log.info('{} already exists and is up-to-date'.format(
-                scratch_db_path))
-            return
-
     scratch_db_tmp_path = scratch_db_path + '.tmp'
     if exists(scratch_db_tmp_path):
         remove(scratch_db_tmp_path)

--- a/test/unit/msd/test_company.py
+++ b/test/unit/msd/test_company.py
@@ -167,3 +167,23 @@ class TestBuildCompanyNameAndScraperCompanyMapTables(DBTestCase):
         companies = {row['company'] for row in rows}
 
         self.assertEqual(companies, {'L Brands'})
+
+    def test_news_corporation(self):
+        # mark company name as invariant
+        insert_rows(self.scratch_db, 'company_name', [
+            dict(company_name='News Corporation',
+                 scraper_id='corrections.company_name'),
+        ])
+
+        insert_rows(self.scratch_db, 'company', [
+            dict(company='News Corporation',
+                 scraper_id='campaign.climate_counts'),
+        ])
+
+        build_company_name_and_scraper_company_map_tables(
+            self.output_db, self.scratch_db)
+
+        rows = select_all(self.output_db, 'scraper_company_map')
+        companies = {row['company'] for row in rows}
+
+        self.assertEqual(companies, {'News Corporation'})

--- a/test/unit/msd/test_company.py
+++ b/test/unit/msd/test_company.py
@@ -16,6 +16,7 @@ from unittest import TestCase
 from msd.company import build_company_name_and_scraper_company_map_tables
 from msd.company import get_company_aliases
 from msd.company import get_company_names
+from msd.company import pick_company_full
 from msd.company import pick_company_name
 
 from ...db import DBTestCase
@@ -78,6 +79,29 @@ class TestPickCompanyName(TestCase):
             pick_company_name(['Illy', 'illy']),
             'Illy')
 
+
+class TestPickCompanyFull(TestCase):
+
+    def test_empty(self):
+        self.assertRaises(IndexError, pick_company_full, [])
+
+    def test_one(self):
+        self.assertEqual(pick_company_full(['Singularity']), 'Singularity')
+
+    def test_longest(self):
+        self.assertEqual(
+            pick_company_full(['The Coca-Cola Company', 'Coca-Cola']),
+            'The Coca-Cola Company')
+
+    def test_all_caps(self):
+        self.assertEqual(
+            pick_company_full(['ASUS', 'Asus']),
+            'ASUS')
+
+    def test_all_lowercase(self):
+        self.assertEqual(
+            pick_company_full(['Illy', 'illy']),
+            'Illy')
 
 
 class TestBuildCompanyNameAndScraperCompanyMapTables(DBTestCase):

--- a/test/unit/msd/test_company.py
+++ b/test/unit/msd/test_company.py
@@ -16,6 +16,7 @@ from unittest import TestCase
 from msd.company import build_company_name_and_scraper_company_map_tables
 from msd.company import get_company_aliases
 from msd.company import get_company_names
+from msd.company import pick_company_name
 
 from ...db import DBTestCase
 from ...db import insert_rows
@@ -34,7 +35,7 @@ class TestGetCompanyNames(TestCase):
         self.assertEqual(get_company_names('L Brands'), {'L Brands'})
 
     def test_weird_caching_bug(self):
-        # for some reason, would get {'L', 'L Brands'} after calling
+        # would get {'L', 'L Brands'} after calling
         # get_company_aliases()
         get_company_aliases('L Brands')
         self.assertEqual(get_company_names('L Brands'), {'L Brands'})
@@ -51,6 +52,32 @@ class TestGetCompanyNames(TestCase):
         # this tests #12
         self.assertEqual(get_company_names('Servals Pvt Ltd'),
                          {'Servals', 'Servals Pvt Ltd'})
+
+
+
+class TestPickCompanyName(TestCase):
+
+    def test_empty(self):
+        self.assertRaises(IndexError, pick_company_name, [])
+
+    def test_one(self):
+        self.assertEqual(pick_company_name(['Singularity']), 'Singularity')
+
+    def test_shortest(self):
+        self.assertEqual(
+            pick_company_name(['The Coca-Cola Company', 'Coca-Cola']),
+            'Coca-Cola')
+
+    def test_all_caps(self):
+        self.assertEqual(
+            pick_company_name(['ASUS', 'Asus']),
+            'ASUS')
+
+    def test_all_lowercase(self):
+        self.assertEqual(
+            pick_company_name(['Illy', 'illy']),
+            'Illy')
+
 
 
 class TestBuildCompanyNameAndScraperCompanyMapTables(DBTestCase):


### PR DESCRIPTION
This gets rid of the hard-coded company name corrections, in favor of being able to do the same thing with `company_name` table entries. This fixes #49.

Tried on my dataset, seems to work. Some tests, but nothing comprehensive; more like regression tests.

Still need to update docs, will do that in a later pull.

Also made the `msd` tool take a `-V` (version) option and run with zero inputs, and removed `./` from scraper IDs (see #46).

Made all-caps company names preferable, which is related to #47.

Also added a correction for "... Corp" (should be "Corp."), and got rid of reusing the scratch table between runs (too error prone).
