### PR TITLE
brands & subsidiaries

### DIFF
--- a/msd/brand.py
+++ b/msd/brand.py
@@ -22,6 +22,8 @@ from .merge import merge_dicts
 from .merge import output_row
 from .norm import smunch
 from .scratch import scratch_tables_with_cols
+from .subsidiary import is_subsidiary
+from .subsidiary import select_company_to_depth
 from .url import match_urls
 
 log = getLogger(__name__)
@@ -72,47 +74,73 @@ def build_scraper_brand_map_table(output_db, scratch_db):
     log.info('  building scraper_brand_map table')
     create_output_table(output_db, 'scraper_brand_map')
 
-    # TODO: will need to redo this by company family tree
-    for (company,), company_map_rows in select_groups(
-            output_db, 'scraper_company_map', ['company']):
+    companies_sql = 'SELECT DISTINCT(company) FROM scraper_company_map'
 
-        scraper_companies = set(
-            (row['scraper_id'], row['scraper_company'])
-            for row in company_map_rows)
+    for (company,) in output_db.execute(companies_sql):
+        # we'll get to this along with its parent compan(ies)
+        if is_subsidiary(output_db, company):
+            continue
 
-        fill_brands_for_company(
-            output_db, scratch_db, company, scraper_companies)
+        # either the top-level parent company, or a singleton
+        company_to_depth = select_company_to_depth(output_db, company)
+
+        if not company_to_depth:
+            company_to_depth = {company: 0}
+
+        fill_scraper_brand_map_table_for_companies(
+            output_db, scratch_db, company_to_depth)
 
 
-def fill_brands_for_company(output_db, scratch_db, company, scraper_companies):
-    # "brand dicts": dicts containing:
-    # scraper_brands: set of (scraper_id, scraper_company, scraper_brand)
-    # brands: candidates for canonical name of brand
+def fill_scraper_brand_map_table_for_companies(
+        output_db, scratch_db, company_to_depth):
+
+    if not company_to_depth:
+        raise ValueError
+
+    companies = sorted(company_to_depth)
+
+    map_sql = (
+        'SELECT scraper_id, scraper_company, company FROM scraper_company_map'
+        ' WHERE company IN ({})'.format(', '.join('?' for c in companies)))
+
+    scraper_company_map = {
+        (scraper_id, scraper_company): company
+        for scraper_id, scraper_company, company in
+        output_db.execute(map_sql, sorted(company_to_depth))
+    }
+
+    # "brand dicts" containing:
+    # scraper_brands: set of (scraper_id, scraper_company, scraper_brands)
+    # brands: set of candidates for canonical name of brand
+    # companies: set of (canonical) companies for brand, sowe can make
+    #            sure brands get pushed down to subsidiaries
     bds = []
 
-    # get all brand info
-    for table_name in scratch_tables_with_cols(['company', 'brand']):
-        select_sql = ('SELECT brand FROM `{}`'
-                      ' WHERE scraper_id = ? and company = ?'.format(
-                          table_name))
+    for (scraper_id, scraper_company), company in scraper_company_map.items():
+        scraper_brands = select_scraper_brands(
+            scratch_db, scraper_id, scraper_company)
 
-        for scraper_id, scraper_company in scraper_companies:
-            rows = scratch_db.execute(
-                select_sql, [scraper_id, scraper_company])
+        for scraper_brand in scraper_brands:
+            brand, _ = split_brand_and_tm(scraper_brand)
 
-            for row in rows:
-                brand, _ = split_brand_and_tm(row['brand'])
-                if brand:
-                    bds.append(dict(brands={brand}, scraper_brands={
-                        (scraper_id, scraper_company, row['brand'])}))
+            if scraper_brand:
+                bds.append(dict(
+                    scraper_brands={
+                        (scraper_id, scraper_company, scraper_brand)},
+                    brands={brand},
+                    companies={company},
+                ))
 
     # grab company names, to fix capitalization of brand (see #7)
     company_name_sql = (
-        'SELECT `company_name` FROM `company_name` where `company` = ?')
-    company_names = set(row[0] for row in
-                        output_db.execute(company_name_sql, [company]))
+        'SELECT company_name FROM company_name WHERE company IN ({})'.format(
+            ', '.join('?' for c in companies)))
+
+    company_names = {
+        row[0] for row in output_db.execute(company_name_sql, companies)}
+
     for name in company_names:
-        bds.append(dict(brands={name}, scraper_brands=set()))
+        bds.append(dict(scraper_brands={}, brands={name}, companies=set()))
 
     # merge brands
     def keyfunc(bd):
@@ -126,19 +154,26 @@ def fill_brands_for_company(output_db, scratch_db, company, scraper_companies):
             continue
 
         brand = pick_brand_name(bd['brands'], company_names)
+        company = pick_company_for_brand(
+            bd['companies'], bd['brands'], company_to_depth)
 
         for (scraper_id, scraper_company, scraper_brand
-             ) in bd['scraper_brands']:
+                ) in bd['scraper_brands']:
             output_row(output_db, 'scraper_brand_map', dict(
                 brand=brand,
                 company=company,
                 scraper_id=scraper_id,
                 scraper_brand=scraper_brand,
-                scraper_company=scraper_company))
+                scraper_company=scraper_company,
+        ))
 
 
 def select_brands(scratch_db, scraper_companies):
-    """Get all possible brand names for the given company(s)."""
+    """Get all possible brand names for the given compan(ies).
+
+    (Like select_scraper_brands(), but for multiple companies, and
+    automatically strips (tm))
+    """
     brands = set()
 
     for scraper_id, scraper_company in scraper_companies:
@@ -169,20 +204,38 @@ def select_scraper_brands(scratch_db, scraper_id, scraper_company):
 
 def pick_brand_name(names, company_names=()):
     """Given several versions of a brand name, prefer the one
-    that matches a company name, is not all-lowercase,
-    not all-uppercase, longest,
+    that matches a company name, longest, is not all-lowercase,
     starts with a lowercase letter ("iPhone" > "IPhone"),
-    and has the most capital letters ("BlackBerry" > "Blackberry").
+    not all uppercase, has the most capital letters
+    ("BlackBerry" > "Blackberry"), and has the least spaces
+    ("Liquid-Plumr" > "Liquid Plumr").
     """
     def keyfunc(n):
-        return (n not in company_names,
-                n != n.lower(),
-                n != n.upper(),
+        return (n in company_names,
                 len(n),
-                n[0],
-                sum(1 for c in n if c.upper() == c))
+                n != n.lower(),
+                n[0] == n[0].lower(),  # iPhone > IPhone
+                n != n.upper(),  # BlackBerry > BLACKBERRY
+                sum(1 for c in n if c.upper() == c),  # BlackBerry > Blackberry
+                -len(n.split()))
 
     return sorted(names, key=keyfunc, reverse=True)[0]
+
+
+def pick_company_for_brand(companies, brand_names, company_to_depth):
+    """Given several companies to which a brand might belong, prefer
+    the one that starts with a proposed brand name, and then company
+    lowest in the subsidiary hierarchy"""
+    brand_keys = {smunch(b) for b in brand_names}
+
+    def keyfunc(company):
+        company_key = smunch(company)
+
+        return(not any(company_key.startswith(bk) for bk in brand_keys),
+               -company_to_depth[company],
+               company)
+
+    return sorted(companies, key=keyfunc)[0]
 
 
 def split_brand_and_tm(scraper_brand):

--- a/msd/brand.py
+++ b/msd/brand.py
@@ -140,7 +140,7 @@ def fill_scraper_brand_map_table_for_companies(
         row[0] for row in output_db.execute(company_name_sql, companies)}
 
     for name in company_names:
-        bds.append(dict(scraper_brands={}, brands={name}, companies=set()))
+        bds.append(dict(scraper_brands=set(), brands={name}, companies=set()))
 
     # merge brands
     def keyfunc(bd):

--- a/msd/brand.py
+++ b/msd/brand.py
@@ -133,7 +133,8 @@ def fill_scraper_brand_map_table_for_companies(
 
     # grab company names, to fix capitalization of brand (see #7)
     company_name_sql = (
-        'SELECT company_name FROM company_name WHERE company IN ({})'.format(
+        'SELECT company_name FROM company_name WHERE company IN ({})'
+        ' AND NOT is_alias'.format(
             ', '.join('?' for c in companies)))
 
     company_names = {

--- a/msd/brand.py
+++ b/msd/brand.py
@@ -128,7 +128,6 @@ def fill_scraper_brand_map_table_for_companies(
                     scraper_brands={
                         (scraper_id, scraper_company, scraper_brand)},
                     brands={brand},
-                    companies={company},
                 ))
 
     # grab company names, to fix capitalization of brand (see #7)
@@ -155,8 +154,10 @@ def fill_scraper_brand_map_table_for_companies(
             continue
 
         brand = pick_brand_name(bd['brands'], company_names)
-        company = pick_company_for_brand(
-            bd['companies'], bd['brands'], company_to_depth)
+        # allow matching brand with any company in hierarchy
+        # e.g. move Tempur-Pedic and Tempur from Sealy to Tempur-Pedic
+        # because they're both owned by Tempur Sealy
+        company = pick_company_for_brand(company_to_depth, bd['brands'])
 
         for (scraper_id, scraper_company, scraper_brand
                 ) in bd['scraper_brands']:
@@ -223,7 +224,7 @@ def pick_brand_name(names, company_names=()):
     return sorted(names, key=keyfunc, reverse=True)[0]
 
 
-def pick_company_for_brand(companies, brand_names, company_to_depth):
+def pick_company_for_brand(company_to_depth, brand_names):
     """Given several companies to which a brand might belong, prefer
     the one that starts with a proposed brand name, and then company
     lowest in the subsidiary hierarchy"""
@@ -236,7 +237,7 @@ def pick_company_for_brand(companies, brand_names, company_to_depth):
                -company_to_depth[company],
                company)
 
-    return sorted(companies, key=keyfunc)[0]
+    return sorted(company_to_depth, key=keyfunc)[0]
 
 
 def split_brand_and_tm(scraper_brand):

--- a/msd/category.py
+++ b/msd/category.py
@@ -204,6 +204,6 @@ def get_implied_categories(output_db, subcategories):
 
     select_sql = ('SELECT DISTINCT `category` from `subcategory`'
                   ' WHERE `subcategory` IN ({})').format(
-                      ', '.join('?' for _ in range(len(subcategories))))
+                      ', '.join('?' for s in subcategories))
 
     return {row[0] for row in output_db.execute(select_sql, subcategories)}

--- a/msd/company.py
+++ b/msd/company.py
@@ -16,7 +16,6 @@ from collections import defaultdict
 from functools import lru_cache
 from logging import getLogger
 
-from .brand import select_brands
 from .company_data import COMPANY_ALIAS_REGEXES
 from .company_data import COMPANY_NAME_REGEXES
 from .company_data import COMPANY_TYPE_CORRECTIONS
@@ -141,6 +140,8 @@ def build_company_name_and_scraper_company_map_tables(output_db, scratch_db):
             continue
 
         # promote aliases to display names if they match a brand
+        from .brand import select_brands
+
         brands = select_brands(scratch_db, cd['scraper_companies'])
         normed_brands = {norm(b) for b in brands}
         brand_names = {a for a in cd['aliases'] if norm(a) in normed_brands}

--- a/msd/norm.py
+++ b/msd/norm.py
@@ -72,5 +72,5 @@ def norm(s):
 
 
 def smunch(s):
-    """Like norm(), except we remove whitespace too."""
-    return WHITESPACE_RE.sub('', norm(s))
+    """Like norm(), except we remove whitespace and hyphens too."""
+    return WHITESPACE_RE.sub('', norm(s)).replace('-', '')

--- a/msd/subsidiary.py
+++ b/msd/subsidiary.py
@@ -87,3 +87,30 @@ def build_subsidiary_table(output_db, scratch_db):
                 subsidiary=company,
                 subsidiary_depth=len(ancestry),
             ))
+
+
+def is_subsidiary(output_db, company):
+    """Is the given company a subsidiary?"""
+    sql = 'SELECT 1 FROM subsidiary WHERE subsidiary = ?'
+
+    rows = list(output_db.execute(sql, [company]))
+
+    return bool(rows)
+
+
+def select_company_to_depth(output_db, parent_company):
+    """Return a map from company to depth for *parent_company* and
+    all its subsidiaries.
+
+    (This will be empty if *parent_company* doesn't appear in the
+    subsidiary table; infer a depth of 0 yourself.)
+    """
+    sql = 'SELECT * FROM subsidiary WHERE company = ?'
+
+    company_to_depth = {}
+
+    for row in output_db.execute(sql, [parent_company]):
+        company_to_depth[row['company']] = row['company_depth']
+        company_to_depth[row['subsidiary']] = row['subsidiary_depth']
+
+    return company_to_depth

--- a/msd/subsidiary.py
+++ b/msd/subsidiary.py
@@ -56,7 +56,8 @@ def build_subsidiary_table(output_db, scratch_db):
         # cycles shouldn't happen; just don't loop forever
         if parents & not_parents:
             log.warning(
-                'cyclical subsidiary relationship for {}'.format(company))
+                'cyclical subsidiary relationship for {} (parents: {})'.format(
+                    company, ', '.join(parents & not_parents)))
             parents = parents - not_parents
 
         if len(parents) == 0:
@@ -75,7 +76,7 @@ def build_subsidiary_table(output_db, scratch_db):
         return sorted(ancestries, key=lambda a: (-len(a), a))[0]
 
     for company in sorted(company_to_parents):
-        pick_ancestry(company, set())
+        pick_ancestry(company, {company})
 
     # output rows
 

--- a/test/unit/msd/test_brand.py
+++ b/test/unit/msd/test_brand.py
@@ -52,7 +52,7 @@ class TestBuildScraperBrandMapTable(DBTestCase):
     SCRATCH_TABLES = [
         'brand', 'category', 'claim', 'rating', 'scraper_brand_map']
 
-    OUTPUT_TABLES = ['company_name', 'scraper_company_map']
+    OUTPUT_TABLES = ['company_name', 'scraper_company_map', 'subsidiary']
 
     def test_merge_differing_capitalization(self):
         # this tests #19

--- a/test/unit/msd/test_brand.py
+++ b/test/unit/msd/test_brand.py
@@ -177,3 +177,14 @@ class TestPickBrandName(TestCase):
 
     def test_one(self):
         self.assertEqual(pick_brand_name(['Apple']), 'Apple')
+
+    def test_iphone(self):
+        self.assertEqual(pick_brand_name(['IPhone', 'iPhone']), 'iPhone')
+
+    def test_all_caps(self):
+        self.assertEqual(pick_brand_name(['Asus', 'ASUS']), 'Asus')
+
+    def test_company_name_match(self):
+        self.assertEqual(
+            pick_brand_name(['Asus', 'ASUS'], company_names={'ASUS'}),
+            'ASUS')

--- a/test/unit/msd/test_brand.py
+++ b/test/unit/msd/test_brand.py
@@ -86,3 +86,46 @@ class TestBuildScraperBrandMapTable(DBTestCase):
                   scraper_company='Newell Rubbermaid',
                   scraper_id='sr.campaign.hrc'),
             ])
+
+    def test_push_brand_down_to_subsidiary(self):
+        # this tests #16
+        insert_rows(self.scratch_db, 'brand', [
+            dict(brand='Puma',
+                 company='Puma',
+                 scraper_id='campaign.btb_fashion'),
+            dict(brand='Puma',
+                 company='Kering SA',
+                 scraper_id='campaign.rankabrand'),
+        ])
+
+        insert_rows(self.output_db, 'scraper_company_map', [
+            dict(company='Puma',
+                 scraper_company='Puma',
+                 scraper_id='campaign.btb_fashion'),
+            dict(company='Kering',
+                 scraper_company='Kering SA',
+                 scraper_id='campaign.rankabrand'),
+        ])
+
+        insert_rows(self.output_db, 'subsidiary', [
+            dict(company='Kering',
+                 company_depth=0,
+                 subsidiary='Puma',
+                 subsidiary_depth=1),
+        ])
+
+        build_scraper_brand_map_table(self.output_db, self.scratch_db)
+
+        self.assertEqual(
+            select_all(self.output_db, 'scraper_brand_map'),
+            [dict(brand='Puma',
+                  company='Puma',
+                  scraper_brand='Puma',
+                  scraper_company='Kering SA',
+                  scraper_id='campaign.rankabrand'),
+             dict(brand='Puma',
+                  company='Puma',
+                  scraper_brand='Puma',
+                  scraper_company='Puma',
+                  scraper_id='campaign.btb_fashion'),
+            ])

--- a/test/unit/msd/test_brand.py
+++ b/test/unit/msd/test_brand.py
@@ -16,6 +16,7 @@ from unittest import TestCase
 
 from msd.brand import build_scraper_brand_map_table
 from msd.brand import pick_brand_name
+from msd.brand import pick_company_for_brand
 from msd.brand import split_brand_and_tm
 from msd.db import insert_row
 
@@ -194,3 +195,28 @@ class TestPickBrandName(TestCase):
         self.assertEqual(
             pick_brand_name(['Blackberry', 'BlackBerry']),
             'BlackBerry')
+
+
+class TestPickCompanyForBrand(TestCase):
+
+    def test_empty(self):
+        self.assertRaises(IndexError, pick_company_for_brand, {}, set())
+
+    def test_one(self):
+        self.assertEqual(
+            pick_company_for_brand({'Clorox': 0}, {'Liquid-Plumr'}),
+            'Clorox')
+
+    def test_match_name(self):
+        self.assertEqual(
+            pick_company_for_brand(
+                {'Sealy': 1, 'Tempur-Pedic': 1, 'Tempur Sealy': 0},
+                {'Tempur'}),
+            'Tempur-Pedic')
+
+    def test_pick_deepest_company(self):
+        self.assertEqual(
+            pick_company_for_brand(
+                {'MEGA Brands': 1, 'Mattel': 0},
+                {'Rose Art'}),
+            'MEGA Brands')

--- a/test/unit/msd/test_brand.py
+++ b/test/unit/msd/test_brand.py
@@ -185,6 +185,12 @@ class TestPickBrandName(TestCase):
         self.assertEqual(pick_brand_name(['Asus', 'ASUS']), 'Asus')
 
     def test_company_name_match(self):
+        # tests #40
         self.assertEqual(
             pick_brand_name(['Asus', 'ASUS'], company_names={'ASUS'}),
             'ASUS')
+
+    def test_more_caps(self):
+        self.assertEqual(
+            pick_brand_name(['Blackberry', 'BlackBerry']),
+            'BlackBerry')


### PR DESCRIPTION
If a brand is shared by companies in the same corporate family tree, we pick one, generally the one deepest in the tree (fixes #15).

Fixed and tested matching capitalization of brand to company (fixes #40).

Merged brands that are the same except for hyphens (e.g. Liquid(-)Plumr) (fixes #31)

Also fixed an issue that happens when companies end up listed as a subsidiary of themselves and tested it.
